### PR TITLE
typo maill -> mail

### DIFF
--- a/common/libnetmagis.tcl
+++ b/common/libnetmagis.tcl
@@ -874,7 +874,7 @@ snit::type ::netmagis {
 					"login" $ldapattrlogin \
 					"lastname" $ldapattrname \
 					"firstname" $ldapattrgivenname \
-					"maill" $ldapattrmail \
+					"mail" $ldapattrmail \
 					"phone" $ldapattrphone \
 					"mobile" $ldapattrmobile \
 					"fax" $ldapattrfax \


### PR DESCRIPTION
One-letter fix for ldap mail attribute name